### PR TITLE
feat(aws): Update to splitting PEM cert configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ $ git init
 
 Above in the table there is a clone command box you can copy from and paste directly into the terminal that concatenates these into one command sequence.
 
-[cloud-signup]: https://cloud.ravendb.net?utm_source=github&utm_medium=web&utm_campaign=github_templates&utm_content=cloud_signup
-[download]: https://ravendb.net/download?utm_source=github&utm_medium=web&utm_campaign=github_templates&utm_content=download
+[cloud-signup]: https://cloud.ravendb.net?utm_source=github&utm_medium=web&utm_campaign=github_templates_home&utm_content=cloud_signup
+[download]: https://ravendb.net/download?utm_source=github&utm_medium=web&utm_campaign=github_templates_home&utm_content=download
 [docs-get-started]: https://ravendb.net/docs/article-page/csharp/start/getting-started?utm_source=github&utm_medium=web&utm_campaign=github_templates&utm_content=docs_get_started
-[learn-bootcamp]: https://ravendb.net/learn/bootcamp?utm_source=github&utm_medium=web&utm_campaign=github_templates&utm_content=learn_bootcamp
-[learn-demo]: https://demo.ravendb.net/?utm_source=github&utm_medium=web&utm_campaign=github_templates&utm_content=learn_demo
+[learn-bootcamp]: https://ravendb.net/learn/bootcamp?utm_source=github&utm_medium=web&utm_campaign=github_templates_home&utm_content=learn_bootcamp
+[learn-demo]: https://demo.ravendb.net/?utm_source=github&utm_medium=web&utm_campaign=github_templates_home&utm_content=learn_demo

--- a/aws-lambda/csharp-http/.gitignore
+++ b/aws-lambda/csharp-http/.gitignore
@@ -227,6 +227,7 @@ ClientBin/
 *.dbproj.schemaview
 *.jfm
 *.pfx
+*.key
 *.publishsettings
 orleans.codegen.cs
 

--- a/aws-lambda/csharp-http/README.md
+++ b/aws-lambda/csharp-http/README.md
@@ -36,21 +36,41 @@ To create a `my-project` directory using this template, run one of the following
   ```
 </details>
 
-For more, see [Cloning the Templates](../../README.md#cloning-the-templates)
+For more, see [Cloning the Templates](../../README.md#cloning-the-templates).
 
-To start the Azure Function:
+You will need to have your AWS environment set up. The easiest method is to use the AWS Toolkit extension for Visual Studio or Visual Studio Code. You can use it to sign in and set up your `~/.aws/credentials` file. You will also need to define a `AWS_REGION` environment variable in your shell profile or environment.
+
+To run the Lambda function locally:
 
 ```sh
-$ dotnet restore
-$ func start
+cd src
+dotnet restore
+dotnet run
 ```
 
+> NOTE: This does not use any simulated Lambda runtime. You may want to use the AWS .NET Mock Lambda tool to test anything Lambda-specific.
 
-## Deploy to Azure
+## Deploy to AWS Lambda
 
-Click the "Deploy to Azure" button above to deploy the ARM template for this repository.
+### Manually
 
-You can also [manually create an Azure Functions app][az-func-deploy].
+You can deploy your function manually through the AWS Lambda .NET Tools:
+
+```sh
+dotnet lambda deploy-function <csproj>
+```
+
+Running this for the first time will walk you through setting up your IAM function role.
+
+### Automatically Using CI/CD
+
+The template is configured to deploy automatically through GitHub Actions workflows for CI/CD. You will need the following secrets and variables:
+
+- **Secret:** `AWS_ACCESS_KEY_ID` -- Your IAM deployment user Access Key ID
+- **Secret:** `AWS_ACCESS_KEY_SECRET` -- Your IAM deployment user Access Key Secret (password-equivalent)
+- **Variable:** `AWS_REGION` -- The AWS region to deploy to (e.g. `us-east-1`)
+- **Variable:** `AWS_LAMBDA_FUNCTION_NAME` -- The AWS Lambda function name, typically the name of the `.csproj` file (e.g. `RavenDBLambda`)
+- **Variable:** `AWS_LAMBDA_FUNCTION_ROLE` -- The IAM role assigned to your AWS Lambda function, created on initial deployment or manually
 
 ## Configuring the Template
 

--- a/aws-lambda/csharp-http/README.md
+++ b/aws-lambda/csharp-http/README.md
@@ -92,22 +92,30 @@ Update the `appsettings.json` or `appsettings.development.json` files:
 }
 ```
 
-### Certificate Path (Windows / Linux)
+#### Using a PFX/X509 Certificate locally
+
+Use the `CertFilePath` to use a PFX file locally, **stored outside the repository.**
 
 The path to the certificate can be relative to the `.csproj` file or an absolute file path.
 
-### Storing the `CertPassword` secret
+> ❗ Avoid storing PFX files in your repository and deploying them. Use the contents of your PEM file instead, see below.
 
-To store `RavenSettings:CertPassword`, you can use User Secrets locally and AWS Lambda when deployed.
+#### Using a PEM Certificate
 
-```bash
-dotnet user-secrets init
-dotnet user-secrets set RavenSettings:CertPassword "<PASSWORD>"
+Instead of uploading a PFX file, in your AWS Lambda function, you will need to define a `RavenSettings__CertPem` environment variable. This will contain BOTH your public and private key in plaintext.
+
+You can copy/paste the contents of your `.pem` file, which will look like this:
+
+```
+-----BEGIN CERTIFICATE-----
+MIIFCzCC...
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKAI...
+-----END RSA PRIVATE KEY-----
 ```
 
-In the AWS Lambda environment variables settings, add a `RavenSettings__CertPassword` variable.
-
-> You do not need to "encrypt-in-transit." This requires a custom configuration provider. Instead, use AWS Secrets Manager.
+The template will handle this for you and pass it to the `DocumentStore`.
 
 ### Using AWS Secrets Manager
 

--- a/aws-lambda/csharp-http/README.md
+++ b/aws-lambda/csharp-http/README.md
@@ -1,1 +1,122 @@
-# RavenDB AWS Lambda C# Template
+# RavenDB AWS Lambda .NET C# Template
+
+A batteries included template for kick starting a .NET C# Minimal Web API AWS Lambda app that connects with a RavenDB database backend.
+
+[RavenDB][cloud-signup] is a NoSQL document database for distributed applications offering industry-leading security without compromising performance. With a RavenDB database you can set up a NoSQL data architecture or add a NoSQL layer to your current relational database.
+
+> The easiest way to get started with RavenDB is by creating [a free RavenDB Cloud account][cloud-signup] or requesting a free license to [download it yourself][download].
+>
+> If you are _brand new_ to RavenDB, we recommend starting with the [Getting Started guide][docs-get-started], the [RavenDB bootcamp][learn-bootcamp], or the [Try RavenDB][learn-demo] experience.
+
+## Use the Template
+
+To create a `my-project` directory using this template, run one of the following sets of commands:
+
+<details>
+  <summary>Clone Command (npx):</summary> 
+  
+  ```sh
+  npx degit ravendb/templates/aws-lambda/csharp-http my-project; cd my-project; git init
+  ```
+</details>
+
+<details>
+  <summary>Clone Command (Bash):</summary> 
+  
+  ```sh
+  git clone https://github.com/ravendb/templates my-project; cd my-project; git filter-branch --subdirectory-filter aws-lambda/csharp-http; rm -rf .git; git init
+  ```
+</details>
+
+<details>
+  <summary>Clone Command (Powershell):</summary>
+
+  ```sh
+  git clone https://github.com/ravendb/templates my-project; cd my-project; git filter-branch --subdirectory-filter aws-lambda/csharp-http; rm -r -force .git; git init
+  ```
+</details>
+
+For more, see [Cloning the Templates](../../README.md#cloning-the-templates)
+
+To start the Azure Function:
+
+```sh
+$ dotnet restore
+$ func start
+```
+
+
+## Deploy to Azure
+
+Click the "Deploy to Azure" button above to deploy the ARM template for this repository.
+
+You can also [manually create an Azure Functions app][az-func-deploy].
+
+## Configuring the Template
+
+Watch the video walkthrough tutorial or read through [the step-by-step guide in the RavenDB docs][docs-howto] that covers how to get up and running successfully with this template.
+
+### RavenDB Settings
+
+The template uses [RavenDB.DependencyInjection][nuget-ravendb-di] to configure RavenDB.
+
+Update the `appsettings.json` or `appsettings.development.json` files:
+
+```json
+{
+  "RavenSettings": {
+    "Urls": ["http://live-test.ravendb.net"],
+    "DatabaseName": "Northwind",
+    "CertFilePath": "path/to/cert.pfx"
+  }
+}
+```
+
+### Certificate Path (Windows / Linux)
+
+The path to the certificate can be relative to the `.csproj` file or an absolute file path.
+
+### Storing the `CertPassword` secret
+
+To store `RavenSettings:CertPassword`, you can use User Secrets locally and AWS Lambda when deployed.
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set RavenSettings:CertPassword "<PASSWORD>"
+```
+
+In the AWS Lambda environment variables settings, add a `RavenSettings__CertPassword` variable.
+
+> You do not need to "encrypt-in-transit." This requires a custom configuration provider. Instead, use AWS Secrets Manager.
+
+### Using AWS Secrets Manager
+
+[AWS Secrets Manager][aws-secrets] is a secure way to store encrypted configuration without relying on environment variables. This incurs extra cost and is enabled through the [Kralizek.Extensions.Configuration.AWSSecretsManager][aws-secrets-nuget] package. If you do not wish to use AWS Secrets Manager, you can safely uninstall it.
+
+To enable loading configuration from AWS Secrets Manager, in `Program.cs`, uncomment the following line:
+
+```csharp
+// builder.Configuration.AddSecretsManager();
+```
+
+> ❗ You will need to grant the `secretsmanager:readwrite` permission set on the Lambda IAM user, otherwise you will run into a runtime exception.
+
+To store and load configuration, create a secret key corresponding to the app setting. For example, here is `RavenSettings` stored as a JSON object:
+
+TBD
+
+Settings will be merged last, meaning you can use it to override specific settings versus loading everything.
+
+Your certificate (.pfx) can be stored as a binary object under the `RavenSettings:CertBytes` setting and will be loaded by the template.
+
+To upload the certificate, use the `aws` CLI:
+
+[cloud-signup]: https://cloud.ravendb.net?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=cloud_signup
+[download]: https://ravendb.net/download?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=download
+[docs-get-started]: https://ravendb.net/docs/article-page/csharp/start/getting-started?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=docs_get_started
+[learn-bootcamp]: https://ravendb.net/learn/bootcamp?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=learn_bootcamp
+[learn-demo]: https://demo.ravendb.net/?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=learn_demo
+[docs-howto]: https://ravendb.net/docs/article/csharp/start/platform-guides/aws-lambda/overview?utm_source=github&utm_medium=web&utm_campaign=github_template_aws_lambda_csharp_http&utm_content=docs_howto
+[nuget-ravendb-di]: https://www.nuget.org/packages/RavenDB.DependencyInjection
+[aws-secrets]: https://aws.amazon.com/secrets-manager/
+[aws-secrets-nuget]: https://www.nuget.org/packages/Kralizek.Extensions.Configuration.AWSSecretsManager

--- a/aws-lambda/csharp-http/src/AppConfiguration.cs
+++ b/aws-lambda/csharp-http/src/AppConfiguration.cs
@@ -8,8 +8,14 @@ public class AppConfiguration
 public class RavenExtendedSettings : RavenSettings
 {
   /// <summary>
-  /// Certificate bytes as UTF8-encoded string
+  /// Certificate bytes (.pfx) as UTF8-encoded string.
   /// </summary>
   /// <value></value>
   public string CertBytes { get; set; }
+
+  /// <summary>
+  /// Certificate PEM with public/private key in plain-text
+  /// </summary>
+  /// <value></value>
+  public string CertPem { get; set; }
 }

--- a/aws-lambda/csharp-http/src/AppConfiguration.cs
+++ b/aws-lambda/csharp-http/src/AppConfiguration.cs
@@ -13,9 +13,15 @@ public class RavenExtendedSettings : RavenSettings
   /// <value></value>
   public string CertBytes { get; set; }
 
-  /// <summary>
-  /// Certificate PEM with public/private key in plain-text
+/// <summary>
+  /// Certificate public key in plain-text. Used in conjunction with CertPrivateKey.
   /// </summary>
   /// <value></value>
-  public string CertPem { get; set; }
+  public string CertPublicKeyFilePath { get; set; }
+
+  /// <summary>
+  /// Certificate private key base64-encoded. Used in conjunction with CertPublicKeyFilePath.
+  /// </summary>
+  /// <value></value>
+  public string CertPrivateKey { get; set; }
 }

--- a/aws-lambda/csharp-http/src/Controllers/WelcomeController.cs
+++ b/aws-lambda/csharp-http/src/Controllers/WelcomeController.cs
@@ -43,6 +43,7 @@ public class WelcomeController : ControllerBase
     {
       welcomeData.connected = false;
       welcomeData.error = ex;
+      Console.WriteLine(ex);
     }
 
     var content = await WelcomeTemplate.RenderHtmlAsync(welcomeData);

--- a/aws-lambda/csharp-http/src/Program.cs
+++ b/aws-lambda/csharp-http/src/Program.cs
@@ -24,6 +24,13 @@ builder.Services.AddRavenDbDocStore(options =>
 
         options.Certificate = cert;
       }
+
+      var certPem = appConfig.RavenSettings.CertPem;
+
+      if (certPem != null)
+      {
+        options.Certificate = X509Certificate2.CreateFromPem(certPem);
+      }
     });
 
 builder.Services.AddControllers();

--- a/aws-lambda/csharp-http/src/RavenDBLambda.csproj
+++ b/aws-lambda/csharp-http/src/RavenDBLambda.csproj
@@ -5,16 +5,18 @@
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
-    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS
+    .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate ready to run images during publishing to improve cold start time. -->
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />    
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
     <PackageReference Include="Kralizek.Extensions.Configuration.AWSSecretsManager" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"
+      Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="RavenDB.Client" Version="5.4.101" />
@@ -30,7 +32,20 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
     <None Update="welcome.tmpl.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>      
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <!-- Avoid accidentally copying X.509 certificates to the publish directory. -->
+    <Content Include="*.pfx">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+    <!-- Allow copying public key certificates to the publish directory. -->
+    <Content Include="*.crt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/aws-lambda/csharp-http/src/appsettings.json
+++ b/aws-lambda/csharp-http/src/appsettings.json
@@ -9,7 +9,6 @@
   "RavenSettings": {
     "Urls": ["http://live-test.ravendb.net"],
     "DatabaseName": "(not set)",
-    "CertFilePath": "",
-    "CertPem": ""
+    "CertPublicKeyFilePath": ""
   }
 }

--- a/aws-lambda/csharp-http/src/appsettings.json
+++ b/aws-lambda/csharp-http/src/appsettings.json
@@ -10,6 +10,6 @@
     "Urls": ["http://live-test.ravendb.net"],
     "DatabaseName": "(not set)",
     "CertFilePath": "",
-    "CertPassword": ""
+    "CertPem": ""
   }
 }

--- a/aws-lambda/csharp-http/src/welcome.tmpl.html
+++ b/aws-lambda/csharp-http/src/welcome.tmpl.html
@@ -47,6 +47,7 @@
       b {
         font-weight: bolder;
         font-weight: 600;
+        color: var(--text-emphasis);
       }
       .background {
         position: fixed;
@@ -550,8 +551,7 @@
                 There was a problem establishing a connection to RavenDB. See
                 below:
               </p>
-              <pre><code>
-{{error.StackTrace}}</code></pre>
+              <p><pre><code>{{error.message}}</code></pre></p>
               <p>
                 To get help, see
                 <a href="#troubleshooting">Troubleshooting Guide</a>.
@@ -574,49 +574,55 @@
                 Update your <code>appsettings.json</code> configuration with
                 your RavenDB connection information.
               </p>
-
+              
               <p>
-                Provide the path to your .pfx file (password-protected) and
-                upload.
+                Provide the path to your .pfx file (with or without a password). <strong>It's recommended not to commit PFX files to source control or deploy them, so the file may be stored outside your repository.</strong>
               </p>
 
               <pre><code>{
   "RavenSettings": {
-    "Urls": ["http://live-test.ravendb.net"],
+    "Urls": ["https://a.free.mycompany.ravendb.cloud"],
     "DatabaseName": "Northwind",
-    "CertFilePath": "path/to/cert.pfx"
-    "CertFilePassword": "&lt;your_password&gt;"
+    "CertFilePath": "../certs/free.mycompany.client.certificate.pfx"
   }
 }</code></pre>
 
+              <p>If using a password-protected PFX, specify the <code>RavenSettings:CertPassword</code> setting as a .NET user secret:</p>
+
+              <pre><code>dotnet user-secrets init
+dotnet user-secrets set "RavenSettings:CertPassword" "&lt;CERT_PASSWORD&gt;"</code></pre>              
+
               <h3>In AWS</h3>
 
+              <p>AWS limits the size of environment variables to under 5KB. A full private/public keypair is typically beyond 5KB in size. To support passing certificate information without deploying a .pfx file or using AWS Secrets Manager, you can use the <code>CertPublicKeyFilePath</code> and <code>CertPrivateKey</code> settings to pass a PEM-encoded public and private key (in .crt and .key files provided by RavenDB):</p>
+
+              <pre><code>{
+  "RavenSettings": {
+    "Urls": ["https://a.free.mycompany.ravendb.cloud"],
+    "DatabaseName": "Northwind",
+    "CertPublicKeyFilePath": "free.mycompany.client.certificate.crt",
+    "CertPrivateKey": "&lt;base64 encoded private key&gt;"
+  }
+}</code></pre>
+
+              <p>The public key certificate (.crt file) is safe to commit to source control and deploy, so it should be relative to the <code>.csproj</code> directory and copied to the output/publish directories:</p>
+
               <p>
-                Ensure your your client certificate (.pfx) is password-protected and
-                deployed alongside your app by updating your <code>.csproj</code> file:
+                Instead of providing the private key in <code>appsettings.json</code> where it will be committed to source control, it's recommended to pass it as an environment variable which can be added to your AWS Lambda
+                function in the Console:
               </p>
 
-              <pre><code>&lt;ItemGroup&gt;
-  &lt;None Update="your.client.certificate.with.password.pfx"&gt;
-    &lt;CopyToOutputDirectory&gt;PreserveNewest&lt;/CopyToOutputDirectory&gt;
-    &lt;CopyToPublishDirectory&gt;PreserveNewest&lt;/CopyToPublishDirectory&gt;
-  &lt;/None&gt;
-&lt;/ItemGroup&gt;
-</code></pre>
-
-              <p>
-                Ensure the environment variables are added to your AWS Lambda function in the Console:
-              </p>
-
-<pre><code>RavenSettings__Urls__0=http://a.free.company.ravendb.cloud
+              <pre><code>RavenSettings__Urls__0=http://a.free.company.ravendb.cloud
 RavenSettings__DatabaseName=MyDatabase
-RavenSettings__CertFilePath=your.client.certificate.with.password.pfx
-RavenSettings__CertPassword=MYPASSWORD
+RavenSettings__CertPublicKeyFilePath=your.client.certificate.with.password.pfx
+RavenSettings__CertPrivateKey=&lt;base64 encoded private key&gt;
 </code></pre>
 
+              <p>The private key contents will need to be <a href="https://www.base64encode.org/">base64-encoded</a> which the template automatically supports.</p>
+
               <p>
-                For a more detailed guide, see
-                <a href="#docs">Using AWS Lambda with RavenDB</a>.
+                For a more robust solution, you may wish to use AWS Secrets Manager to manage certificates and configuration. For a more detailed guide, see
+                <a href="https://ravendb.net/docs/article-page/latest/csharp/start/guides/aws-lambda/overview">Using AWS Lambda with RavenDB</a>.
               </p>
             </div>
           </div>

--- a/azure-functions/csharp-http/README.md
+++ b/azure-functions/csharp-http/README.md
@@ -6,25 +6,46 @@
 
 A batteries included template for kick starting a C# Azure Functions app that connects with a RavenDB Cloud database backend.
 
-[RavenDB][cloud-signup] is a business continuity database for distributed applications offering industry-leading security with sub-100ms query performance.
+[RavenDB][cloud-signup] is a NoSQL document database for distributed applications offering industry-leading security without compromising performance. With a RavenDB database you can set up a NoSQL data architecture or add a NoSQL layer to your current relational database.
 
-> The easiest way to get started with RavenDB is by creating [a free RavenDB Cloud account](cloud-signup).
+> The easiest way to get started with RavenDB is by creating [a free RavenDB Cloud account][cloud-signup] or requesting a free license to [download it yourself][download].
 >
-> If you are _brand new_ to RavenDB, we recommend starting with the [Getting Started guide](docs-get-started), the [RavenDB bootcamp](learn-bootcamp), or the [Try RavenDB](learn-demo) experience.
+> If you are _brand new_ to RavenDB, we recommend starting with the [Getting Started guide][docs-get-started], the [RavenDB bootcamp][learn-bootcamp], or the [Try RavenDB][learn-demo] experience.
 
 ## Use the Template
 
-To create a `my-project` directory using this template, run:
+To create a `my-project` directory using this template, run one of the following sets of commands:
 
-```sh
-$ git clone https://github.com/ravendb/template-azure-functions-csharp my-project
-$ cd my-project
-$ func start
-```
+<details>
+  <summary>Clone Command (npx):</summary> 
+  
+  ```sh
+  npx degit ravendb/templates/azure-functions/csharp-http my-project; cd my-project; git init
+  ```
+</details>
+
+<details>
+  <summary>Clone Command (Bash):</summary> 
+  
+  ```sh
+  git clone https://github.com/ravendb/templates my-project; cd my-project; git filter-branch --subdirectory-filter azure-functions/csharp-http; rm -rf .git; git init
+  ```
+</details>
+
+<details>
+  <summary>Clone Command (Powershell):</summary>
+
+  ```sh
+  git clone https://github.com/ravendb/templates my-project; cd my-project; git filter-branch --subdirectory-filter azure-functions/csharp-http; rm -r -force .git; git init
+  ```
+</details>
+
+For more, see [Cloning the Templates](../../README.md#cloning-the-templates)
 
 To start the Azure Function:
 
 ```sh
+$ dotnet restore
 $ func start
 ```
 
@@ -40,7 +61,7 @@ Watch the video walkthrough tutorial or read through [the step-by-step guide in 
 
 ### RavenDB Settings
 
-The template uses [RavenDB.DependencyInjection][gh-ravendb-di] to configure RavenDB.
+The template uses [RavenDB.DependencyInjection][nuget-ravendb-di] to configure RavenDB.
 
 Update the `appsettings.json` or `appsettings.development.json` files:
 
@@ -83,9 +104,11 @@ Specifying the `RavenSettings:CertThumbprint` will search the Windows Certificat
 Optionally you could store the certificate in Azure Key Vault, retrieve the bytes, and build the `X509Certificate2` to provide to the DocumentStore.
 
 [cloud-signup]: https://cloud.ravendb.net?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=cloud_signup
+[download]: https://ravendb.net/download?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=download
 [docs-get-started]: https://ravendb.net/docs/article-page/csharp/start/getting-started?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=docs_get_started
 [docs-create-db]: https://ravendb.net/docs/article-page/csharp/studio/database/create-new-database/general-flow?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=docs_new_db
 [learn-bootcamp]: https://ravendb.net/learn/bootcamp?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=learn_bootcamp
 [learn-demo]: https://demo.ravendb.net/?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=learn_demo
 [docs-howto]: https://ravendb.net/docs/article/csharp/start/platform-guides/azure-functions/overview?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_csharp&utm_content=docs_howto
+[nuget-ravendb-di]: https://www.nuget.org/packages/RavenDB.DependencyInjection 
 [az-func-deploy]: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-vs-code-csharp?tabs=in-process#deploy-the-project-to-azure

--- a/azure-functions/node-http/.gitignore
+++ b/azure-functions/node-http/.gitignore
@@ -1,3 +1,6 @@
+# Certificates
+*.pfx
+
 # Logs
 logs
 *.log

--- a/azure-functions/node-http/README.md
+++ b/azure-functions/node-http/README.md
@@ -4,28 +4,29 @@
 
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fravendb%2Ftemplate-azure-functions-typescript%2Fmaster%2Fazuredeploy.json)
 
-A batteries included template for kick starting a Node.js TypeScript Azure Functions project that connects with a RavenDB Cloud database backend.
+A batteries included template for kick starting a Node.js TypeScript Azure Functions project that connects with a RavenDB database backend.
 
-[RavenDB][cloud-signup] is a business continuity database for distributed applications offering industry-leading security with sub-100ms query performance.
+[RavenDB][cloud-signup] is a NoSQL document database for distributed applications offering industry-leading security without compromising performance. With a RavenDB database you can set up a NoSQL data architecture or add a NoSQL layer to your current relational database.
 
-> The easiest way to get started with RavenDB is by creating [a free RavenDB Cloud account](cloud-signup).
+> The easiest way to get started with RavenDB is by creating [a free RavenDB Cloud account][cloud-signup] or requesting a free license to [download it yourself][download].
 >
-> If you are _brand new_ to RavenDB, we recommend starting with the [Getting Started guide](docs-get-started), the [RavenDB bootcamp](learn-bootcamp), or the [Try RavenDB](learn-demo) experience.
+> If you are _brand new_ to RavenDB, we recommend starting with the [Getting Started guide][docs-get-started], the [RavenDB bootcamp][learn-bootcamp], or the [Try RavenDB][learn-demo] experience.
 
 ## Use the Template
 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ git clone https://github.com/ravendb/template-azure-functions-typescript my-project
-$ cd my-project
-$ func start
+npx degit ravendb/templates/azure-functions/node-http my-project
+cd my-project
+git init
 ```
 
 To start the Azure Function:
 
 ```sh
-$ func start
+npm install
+func start
 ```
 
 ## Deploy to Azure
@@ -87,6 +88,7 @@ The template will handle this for you and pass it to the `DocumentStore`.
 Optionally you could store the certificate in Azure Key Vault, retrieve the bytes, and pass the buffer to the DocumentStore. This incurs extra cost both in terms of storage and network latency.
 
 [cloud-signup]: https://cloud.ravendb.net?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_typescript&utm_content=cloud_signup
+[download]: https://ravendb.net/download?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_typescript&utm_content=download
 [docs-get-started]: https://ravendb.net/docs/article-page/nodejs/start/getting-started?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_typescript&utm_content=docs_get_started
 [docs-create-db]: https://ravendb.net/docs/article-page/csharp/studio/database/create-new-database/general-flow?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_typescript&utm_content=docs_new_db
 [learn-bootcamp]: https://ravendb.net/learn/bootcamp?utm_source=github&utm_medium=web&utm_campaign=github_template_az_func_typescript&utm_content=learn_bootcamp


### PR DESCRIPTION
## Changes

- Update AWS template to support using a `CertPublicKeyFilePath` and `CertPrivateKey` configuration method since AWS limits environment variables and we want to avoid deploying PFX files

## Other Changes

- Align some of the READMEs for consistency